### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable, beta]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -28,19 +28,19 @@ jobs:
           components: rustfmt, clippy
       
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
       
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
       
       - name: Cache cargo build
-        uses: actions/cache@v4
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684  # v4.2.3
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
@@ -61,7 +61,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Install cargo-audit
         run: cargo install cargo-audit
@@ -73,7 +73,7 @@ jobs:
     name: Code Coverage
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -85,7 +85,7 @@ jobs:
         run: cargo tarpaulin --out xml
       
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24  # v5.4.3
         with:
           file: ./cobertura.xml
           fail_ci_if_error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Create Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e  # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -50,7 +50,7 @@ jobs:
             asset_name: file-scanner-windows-amd64.exe
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -82,7 +82,7 @@ jobs:
         shell: bash
       
       - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1
+        uses: actions/upload-release-asset@e8f9f06c4b078e705bd2ea027f0926603fc9b4d5  # v1.0.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -96,13 +96,13 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
       
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2  # v3.10.0
       
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772  # v3.4.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
@@ -110,7 +110,7 @@ jobs:
       
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@902fa8ec7d6ecbf8d84d538b9b233a880e428804  # v5.7.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -119,7 +119,7 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
       
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83  # v6.18.0
         with:
           context: .
           platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
This PR updates the following GitHub Actions to their latest versions:

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/cache`
  * From: v4 ()
  * To: v4.2.3 (5a3ec84eff668545956fd18022155c47e93e2684)

* `actions/cache`
  * From: v4 ()
  * To: v4.2.3 (5a3ec84eff668545956fd18022155c47e93e2684)

* `actions/cache`
  * From: v4 ()
  * To: v4.2.3 (5a3ec84eff668545956fd18022155c47e93e2684)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `codecov/codecov-action`
  * From: v4 ()
  * To: v5.4.3 (18283e04ce6e62d37312384ff67231eb8fd56d24)

* `actions/create-release`
  * From: v1 ()
  * To: v1.1.4 (0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `actions/upload-release-asset`
  * From: v1 ()
  * To: v1.0.2 (e8f9f06c4b078e705bd2ea027f0926603fc9b4d5)

* `actions/checkout`
  * From: v4 ()
  * To: v4.2.2 (11bd71901bbe5b1630ceea73d27597364c9af683)

* `docker/setup-buildx-action`
  * From: v3 ()
  * To: v3.10.0 (b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2)

* `docker/login-action`
  * From: v3 ()
  * To: v3.4.0 (74a5d142397b4f367a81961eba4e8cd7edddf772)

* `docker/metadata-action`
  * From: v5 ()
  * To: v5.7.0 (902fa8ec7d6ecbf8d84d538b9b233a880e428804)

* `docker/build-push-action`
  * From: v5 ()
  * To: v6.18.0 (263435318d21b8e681c14492fe198d362a7d2c83)

---
🔒 This PR uses commit hashes for improved security.
🤖 This PR was created automatically by the GitHub Actions workflow updater.