### PR TITLE
chore: update rmcp to 0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1000,8 +1000,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b136475da5ef7b6ac596c0e956e37bad51b85b987ff3d5e230e964936736b2"
+dependencies = [
+ "darling_core 0.21.1",
+ "darling_macro 0.21.1",
 ]
 
 [[package]]
@@ -1019,12 +1029,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44ad32f92b75fb438b04b68547e521a548be8acc339a6dacc4a7121488f53e6"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b5be8a7a562d315a5b92a630c30cec6bcf663e6673f00fbb69cca66a6f521b9"
+dependencies = [
+ "darling_core 0.21.1",
  "quote",
  "syn 2.0.104",
 ]
@@ -1325,7 +1360,7 @@ dependencies = [
  "ring",
  "rmcp",
  "rstest",
- "schemars 1.0.4",
+ "schemars",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -3395,8 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.1.5"
-source = "git+https://github.com/modelcontextprotocol/rust-sdk?rev=db03f63#db03f63e76b5b32f65d34a1bd08ae56dab595f60"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a04b2d9da174d72bc0511410242eb3e8f47a02d9e23868e4b076c7c70208eb4"
 dependencies = [
  "base64",
  "chrono",
@@ -3404,7 +3440,7 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "rmcp-macros",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -3415,9 +3451,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.1.5"
-source = "git+https://github.com/modelcontextprotocol/rust-sdk?rev=db03f63#db03f63e76b5b32f65d34a1bd08ae56dab595f60"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470958f96a5700478601c385ad3d987460372c2223959eddcb682c7273cdfb86"
 dependencies = [
+ "darling 0.21.1",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -3692,40 +3730,16 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "chrono",
- "dyn-clone",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.0.4",
+ "schemars_derive",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.104",
 ]
 
 [[package]]
@@ -5442,7 +5456,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88535b229ed05a4fce90def2b855fbec9c82463b02ec64db2312ea0702ed9288"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.104",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio = { version = "1.47", features = ["full"] }
 ring = "0.17"
 
 # MCP SDK
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", rev = "db03f63", features = ["transport-io"] }
+rmcp = { version = "=0.4.0", features = ["transport-io"] }
 schemars = "1.0"
 
 # HTTP server for MCP

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use rmcp::{
     handler::server::wrapper::Json,
     model::{Implementation, ProtocolVersion, ServerCapabilities, ServerInfo},
-    schemars, tool, ServerHandler,
+    schemars, ServerHandler,
 };
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -246,14 +246,14 @@ pub struct PythonAnalysisRequest {
 #[derive(Debug, Clone)]
 pub struct FileScannerMcp;
 
-#[tool(tool_box)]
 impl FileScannerMcp {
-    #[tool(
-        description = "Comprehensive file analysis tool - use 'all' flag to enable all analyses, or individual flags to control specific analyses (metadata, hashes, strings, hex_dump, binary_info, signatures, symbols, control_flow, vulnerabilities, code_quality, dependencies, entropy, disassembly, threats, behavioral, yara_indicators)"
-    )]
+    pub fn new() -> Self {
+        FileScannerMcp
+    }
+
     pub async fn analyze_file(
         &self,
-        #[tool(aggr)] request: FileAnalysisRequest,
+        request: FileAnalysisRequest,
     ) -> Result<Json<FileAnalysisResult>, String> {
         let path = PathBuf::from(&request.file_path);
 
@@ -572,12 +572,9 @@ impl FileScannerMcp {
         Ok(Json(result))
     }
 
-    #[tool(
-        description = "LLM-optimized file analysis for YARA rule generation - returns focused, token-limited output with key indicators"
-    )]
-    pub async fn llm_analyze_file(
+        pub async fn llm_analyze_file(
         &self,
-        #[tool(aggr)] request: LlmFileAnalysisRequest,
+         request: LlmFileAnalysisRequest,
     ) -> Result<Json<LlmFileAnalysisResult>, String> {
         use crate::{
             binary_parser::parse_binary, entropy_analysis::analyze_entropy,
@@ -874,12 +871,9 @@ impl FileScannerMcp {
         result
     }
 
-    #[tool(
-        description = "Scan files with custom YARA rules - supports single files or directories with recursive scanning"
-    )]
-    pub async fn yara_scan_file(
+        pub async fn yara_scan_file(
         &self,
-        #[tool(aggr)] request: YaraScanRequest,
+         request: YaraScanRequest,
     ) -> Result<Json<YaraScanResult>, String> {
         use crate::threat_detection::scan_with_custom_rule;
         use std::time::Instant;
@@ -917,12 +911,9 @@ impl FileScannerMcp {
         }))
     }
 
-    #[tool(
-        description = "Analyze Java archives (JAR/WAR/EAR/APK/AAR) and class files - provides detailed Java/Android specific analysis including manifests, certificates, classes, and security assessment"
-    )]
-    pub async fn analyze_java_file(
+        pub async fn analyze_java_file(
         &self,
-        #[tool(aggr)] request: JavaAnalysisRequest,
+         request: JavaAnalysisRequest,
     ) -> Result<Json<JavaAnalysisResult>, String> {
         let path = PathBuf::from(&request.file_path);
 
@@ -946,12 +937,9 @@ impl FileScannerMcp {
         Ok(Json(analysis_result))
     }
 
-    #[tool(
-        description = "Analyze npm packages for vulnerabilities and malicious code - detects typosquatting, supply chain attacks, malware patterns, and known vulnerabilities. Works with .tgz files or directories containing package.json"
-    )]
-    pub async fn analyze_npm_package(
+        pub async fn analyze_npm_package(
         &self,
-        #[tool(aggr)] request: NpmAnalysisRequest,
+         request: NpmAnalysisRequest,
     ) -> Result<Json<NpmPackageAnalysis>, String> {
         let path = PathBuf::from(&request.package_path);
 
@@ -964,12 +952,9 @@ impl FileScannerMcp {
         Ok(Json(analysis_result))
     }
 
-    #[tool(
-        description = "Analyze Python packages for vulnerabilities and malicious code - detects typosquatting, supply chain attacks, malware patterns, and known vulnerabilities. Works with .whl, .tar.gz, .zip files or directories containing setup.py/pyproject.toml"
-    )]
-    pub async fn analyze_python_package(
+        pub async fn analyze_python_package(
         &self,
-        #[tool(aggr)] request: PythonAnalysisRequest,
+         request: PythonAnalysisRequest,
     ) -> Result<Json<PythonPackageAnalysis>, String> {
         let path = PathBuf::from(&request.package_path);
 
@@ -983,7 +968,6 @@ impl FileScannerMcp {
     }
 }
 
-#[tool(tool_box)]
 impl ServerHandler for FileScannerMcp {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
@@ -1000,7 +984,7 @@ impl ServerHandler for FileScannerMcp {
 
 // Public functions for CLI usage
 pub async fn analyze_file_llm(request: LlmFileAnalysisRequest) -> Result<LlmFileAnalysisResult> {
-    let handler = FileScannerMcp;
+    let handler = FileScannerMcp::new();
     let result = handler
         .llm_analyze_file(request)
         .await
@@ -1009,7 +993,7 @@ pub async fn analyze_file_llm(request: LlmFileAnalysisRequest) -> Result<LlmFile
 }
 
 pub async fn yara_scan_files(request: YaraScanRequest) -> Result<YaraScanResult> {
-    let handler = FileScannerMcp;
+    let handler = FileScannerMcp::new();
     let result = handler
         .yara_scan_file(request)
         .await
@@ -1132,7 +1116,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_analyze_file_nonexistent() {
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             all: None,
             file_path: "/nonexistent/file.bin".to_string(),
@@ -1170,7 +1154,7 @@ mod tests {
         let test_content = b"Hello, World! This is test content for analysis.";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             all: None,
             file_path: file_path.to_string_lossy().to_string(),
@@ -1209,7 +1193,7 @@ mod tests {
         let test_content = b"Test content for hash calculation";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             all: None,
             file_path: file_path.to_string_lossy().to_string(),
@@ -1250,7 +1234,7 @@ mod tests {
             b"Hello World! This is a test string for extraction. Another string here.";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             all: None,
             file_path: file_path.to_string_lossy().to_string(),
@@ -1289,7 +1273,7 @@ mod tests {
         let test_content = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             all: None,
             file_path: file_path.to_string_lossy().to_string(),
@@ -1328,7 +1312,7 @@ mod tests {
         let test_content = b"Combined analysis test with various features enabled.";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             all: None,
             file_path: file_path.to_string_lossy().to_string(),
@@ -1367,7 +1351,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_llm_analyze_file_nonexistent() {
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = LlmFileAnalysisRequest {
             file_path: "/nonexistent/file.bin".to_string(),
             token_limit: None,
@@ -1392,7 +1376,7 @@ mod tests {
         let test_content = b"LLM analysis test content with interesting patterns and strings.";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = LlmFileAnalysisRequest {
             file_path: file_path.to_string_lossy().to_string(),
             token_limit: Some(10000),
@@ -1418,7 +1402,7 @@ mod tests {
 
     #[test]
     fn test_extract_key_strings() {
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
 
         // Create mock extracted strings
         let extracted_strings = crate::strings::ExtractedStrings {
@@ -1460,7 +1444,7 @@ mod tests {
         let test_content = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789abcdefghijklmnopqrstuvwxyz";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let result = mcp.extract_hex_patterns(&file_path, 16);
 
         assert!(result.is_ok());
@@ -1482,7 +1466,7 @@ mod tests {
         ];
         let (_temp_dir, file_path) = create_test_file(&test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let result = mcp.extract_key_opcodes(&file_path, 5);
 
         // This test might not find opcodes since it looks at offset 0x1000
@@ -1492,7 +1476,7 @@ mod tests {
 
     #[test]
     fn test_generate_yara_rule_suggestion() {
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
 
         let analysis = LlmFileAnalysisResult {
             md5: "abc123def456".to_string(),
@@ -1522,7 +1506,7 @@ mod tests {
 
     #[test]
     fn test_trim_results_to_token_limit() {
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
 
         let result = LlmFileAnalysisResult {
             md5: "abc123".to_string(),
@@ -1545,7 +1529,7 @@ mod tests {
 
     #[test]
     fn test_server_handler_get_info() {
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let info = mcp.get_info();
 
         assert_eq!(info.server_info.name, "file-scanner");
@@ -1609,7 +1593,7 @@ mod tests {
         let test_content = b"Test content for all flag verification";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             file_path: file_path.to_string_lossy().to_string(),
             all: Some(true),
@@ -1672,7 +1656,7 @@ mod tests {
         let test_content = b"Test content for individual flag verification";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             file_path: file_path.to_string_lossy().to_string(),
             all: Some(false),
@@ -1734,7 +1718,7 @@ mod tests {
         let test_content = b"Test content for default behavior verification";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
         let request = FileAnalysisRequest {
             file_path: file_path.to_string_lossy().to_string(),
             all: None, // Default behavior
@@ -1891,7 +1875,7 @@ mod tests {
         let test_content = b"Comprehensive test content with various features for all flag testing";
         let (_temp_dir, file_path) = create_test_file(test_content).unwrap();
 
-        let mcp = FileScannerMcp;
+        let mcp = FileScannerMcp::new();
 
         // Test 1: Verify 'all: true' enables more analyses than individual flags
         let request_all = FileAnalysisRequest {

--- a/src/mcp_transport.rs
+++ b/src/mcp_transport.rs
@@ -128,7 +128,7 @@ impl McpTransportServer {
         let string_tracker = Arc::new(StringTracker::new());
 
         Self {
-            handler: FileScannerMcp,
+            handler: FileScannerMcp::new(),
             cache,
             string_tracker,
         }
@@ -1017,7 +1017,7 @@ mod tests {
         let sse_clients = Arc::new(Mutex::new(HashMap::new()));
 
         McpServerState {
-            handler: FileScannerMcp,
+            handler: FileScannerMcp::new(),
             sse_clients,
             cache,
             string_tracker,
@@ -1031,7 +1031,7 @@ mod tests {
         let string_tracker = Arc::new(StringTracker::new());
 
         McpTransportServer {
-            handler: FileScannerMcp,
+            handler: FileScannerMcp::new(),
             cache,
             string_tracker,
         }
@@ -1547,7 +1547,7 @@ mod tests {
         let sse_clients = Arc::new(Mutex::new(HashMap::new()));
 
         let _state = McpServerState::new_for_testing(
-            FileScannerMcp,
+            FileScannerMcp::new(),
             sse_clients.clone(),
             cache.clone(),
             string_tracker.clone(),
@@ -1791,7 +1791,7 @@ mod tests {
         let sse_clients = Arc::new(Mutex::new(HashMap::new()));
 
         let _state = McpServerState::new_for_testing(
-            FileScannerMcp,
+            FileScannerMcp::new(),
             sse_clients.clone(),
             cache.clone(),
             string_tracker.clone(),

--- a/tests/integration/mcp_server_test.rs
+++ b/tests/integration/mcp_server_test.rs
@@ -5,7 +5,7 @@ use std::path::PathBuf;
 use tempfile::TempDir;
 
 async fn create_test_server() -> FileScannerMcp {
-    FileScannerMcp
+    FileScannerMcp::new()
 }
 
 fn create_test_file(dir: &TempDir, name: &str, content: &[u8]) -> PathBuf {

--- a/tests/integration/mcp_transport_test.rs
+++ b/tests/integration/mcp_transport_test.rs
@@ -351,7 +351,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_mcp_server_state_creation() {
-        let handler = FileScannerMcp;
+        let handler = FileScannerMcp::new();
         let sse_clients = Arc::new(Mutex::new(HashMap::new()));
         let cache_dir = std::env::temp_dir().join("test-file-scanner-cache");
         let cache = Arc::new(

--- a/tests/mcp_server_unit_test.rs
+++ b/tests/mcp_server_unit_test.rs
@@ -15,7 +15,7 @@ fn create_test_file(content: &[u8]) -> anyhow::Result<(TempDir, std::path::PathB
 
 #[test]
 fn test_file_scanner_mcp_creation() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
 
     // Test that we can create the MCP server
     let info = mcp.get_info();
@@ -27,7 +27,7 @@ fn test_file_scanner_mcp_creation() {
 
 #[test]
 fn test_mcp_server_info_structure() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let info = mcp.get_info();
 
     // Verify server info fields
@@ -50,7 +50,7 @@ fn test_mcp_server_info_structure() {
 
 #[tokio::test]
 async fn test_file_analysis_request_validation() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"test content").unwrap();
 
     // Test valid request
@@ -84,7 +84,7 @@ async fn test_file_analysis_request_validation() {
 
 #[tokio::test]
 async fn test_file_analysis_request_invalid_path() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
 
     let request = FileAnalysisRequest {
         all: None,
@@ -116,7 +116,7 @@ async fn test_file_analysis_request_invalid_path() {
 
 #[tokio::test]
 async fn test_llm_file_analysis_request_validation() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"test content for LLM analysis").unwrap();
 
     let request = LlmFileAnalysisRequest {
@@ -140,7 +140,7 @@ async fn test_llm_file_analysis_request_validation() {
 
 #[tokio::test]
 async fn test_llm_file_analysis_with_defaults() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"default analysis test").unwrap();
 
     let request = LlmFileAnalysisRequest {
@@ -166,7 +166,7 @@ async fn test_llm_file_analysis_with_defaults() {
 
 #[tokio::test]
 async fn test_file_analysis_metadata_only() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"metadata test content").unwrap();
 
     let request = FileAnalysisRequest {
@@ -206,7 +206,7 @@ async fn test_file_analysis_metadata_only() {
 
 #[tokio::test]
 async fn test_file_analysis_hashes_only() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"hash test content").unwrap();
 
     let request = FileAnalysisRequest {
@@ -249,7 +249,7 @@ async fn test_file_analysis_hashes_only() {
 
 #[tokio::test]
 async fn test_file_analysis_strings_with_parameters() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let content = b"Short\x00LongerString\x00VeryLongStringForTesting\x00";
     let (_temp_dir, file_path) = create_test_file(content).unwrap();
 
@@ -292,7 +292,7 @@ async fn test_file_analysis_strings_with_parameters() {
 
 #[tokio::test]
 async fn test_file_analysis_hex_dump_with_parameters() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let content = b"0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
     let (_temp_dir, file_path) = create_test_file(content).unwrap();
 
@@ -335,7 +335,7 @@ async fn test_file_analysis_hex_dump_with_parameters() {
 
 #[tokio::test]
 async fn test_file_analysis_request_all_options_false() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"test").unwrap();
 
     let request = FileAnalysisRequest {
@@ -375,7 +375,7 @@ async fn test_file_analysis_request_all_options_false() {
 
 #[tokio::test]
 async fn test_file_analysis_binary_file() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
 
     // Create a minimal ELF-like file
     let mut content = vec![0x7f, 0x45, 0x4c, 0x46]; // ELF magic
@@ -430,7 +430,7 @@ async fn test_file_analysis_binary_file() {
 
 #[tokio::test]
 async fn test_llm_analysis_token_limit_enforcement() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
 
     // Create a file with many strings
     let mut content = Vec::new();
@@ -529,7 +529,7 @@ fn test_llm_file_analysis_request_structure() {
 
 #[tokio::test]
 async fn test_file_analysis_empty_file() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"").unwrap();
 
     let request = FileAnalysisRequest {
@@ -583,7 +583,7 @@ async fn test_file_analysis_empty_file() {
 
 #[tokio::test]
 async fn test_llm_analysis_empty_file() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"").unwrap();
 
     let request = LlmFileAnalysisRequest {
@@ -611,7 +611,7 @@ async fn test_llm_analysis_empty_file() {
 
 #[tokio::test]
 async fn test_file_analysis_permission_error() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
 
     // Try to analyze a system file that might not be readable
     let request = FileAnalysisRequest {
@@ -645,7 +645,7 @@ async fn test_file_analysis_permission_error() {
 
 #[tokio::test]
 async fn test_file_analysis_response_structure() {
-    let mcp = FileScannerMcp;
+    let mcp = FileScannerMcp::new();
     let (_temp_dir, file_path) = create_test_file(b"response structure test").unwrap();
 
     let request = FileAnalysisRequest {

--- a/tests/mcp_transport_comprehensive_test.rs
+++ b/tests/mcp_transport_comprehensive_test.rs
@@ -19,7 +19,7 @@ fn create_test_state() -> McpServerState {
     let string_tracker = Arc::new(StringTracker::new());
     let sse_clients = Arc::new(Mutex::new(HashMap::new()));
 
-    McpServerState::new_for_testing(FileScannerMcp, sse_clients, cache, string_tracker)
+    McpServerState::new_for_testing(FileScannerMcp::new(), sse_clients, cache, string_tracker)
 }
 
 // Helper function to create a test transport server


### PR DESCRIPTION
## Summary
- bump rmcp to 0.4.0
- adapt FileScannerMcp initialization and tests
- remove legacy MCP macros

## Testing
- `cargo check --tests`

------
https://chatgpt.com/codex/tasks/task_e_6895345cf76883279c06fd0494a89f96