### PR TITLE
Fix CI disk space issues for parallel tests

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,19 @@
+# Cargo configuration
+# CI-specific settings are applied via environment variables in the scripts
+
+[build]
+# Default build settings for development
+# CI environments will override these via CARGO_BUILD_JOBS
+
+[profile.test]
+# Default test profile for development
+# CI environments will override these settings via environment variables
+opt-level = 1
+debug = true
+incremental = true
+
+# Note: CI-specific settings are applied in scripts/test-parallel-ci.sh via:
+# - CARGO_PROFILE_TEST_DEBUG=0
+# - CARGO_PROFILE_TEST_CODEGEN_UNITS=1
+# - CARGO_PROFILE_TEST_LTO="thin"
+# - CARGO_PROFILE_TEST_INCREMENTAL=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,6 +162,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup swap space
+        run: |
+          echo "📊 Current memory and swap:"
+          free -h
+          sudo fallocate -l 4G /swapfile
+          sudo chmod 600 /swapfile
+          sudo mkswap /swapfile
+          sudo swapon /swapfile
+          echo "📊 Memory and swap after setup:"
+          free -h
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
@@ -190,8 +201,20 @@ jobs:
       - name: Make scripts executable
         run: chmod +x scripts/*.sh
 
+      - name: Free disk space before tests
+        run: |
+          echo "📊 Initial disk space:"
+          df -h
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /opt/ghc || true
+          sudo rm -rf /usr/local/.ghcup || true
+          sudo apt-get clean || true
+          echo "📊 Disk space after cleanup:"
+          df -h
+
       - name: Run comprehensive parallel tests
-        run: ./scripts/test-parallel.sh
+        run: ./scripts/test-parallel-ci.sh
 
   coverage:
     name: Code Coverage

--- a/CI_DISK_SPACE_FIX.md
+++ b/CI_DISK_SPACE_FIX.md
@@ -1,0 +1,54 @@
+# CI Disk Space Fix for Parallel Tests
+
+## Problem
+GitHub Actions runners were running out of disk space during parallel test compilation with the error:
+```
+/usr/bin/ld: final link failed: No space left on device
+```
+
+## Solution
+Created a CI-optimized test runner that:
+
+1. **Reduces parallelism** - Limits to 2 parallel jobs instead of all CPU cores
+2. **Frees disk space** - Removes unnecessary pre-installed software
+3. **Optimizes binary size** - Uses minimal debug info and thin LTO
+4. **Runs tests in batches** - Cleans artifacts between test types
+5. **Adds swap space** - Creates 4GB swap file for more virtual memory
+
+## Changes Made
+
+### 1. New CI-optimized test script: `scripts/test-parallel-ci.sh`
+- Detects CI environment and applies optimizations
+- Runs tests in batches with cleanup between
+- Uses space-saving compiler flags
+
+### 2. Updated `scripts/test-parallel.sh`
+- Automatically delegates to CI script when `$CI` is set
+- Preserves original behavior for local development
+
+### 3. Modified `.github/workflows/ci.yml`
+- Added swap space setup (4GB)
+- Added disk cleanup before tests
+- Uses new CI-optimized script
+
+### 4. Created `.cargo/config.toml`
+- Documents CI-specific settings
+- Maintains development-friendly defaults
+
+## Key Optimizations
+
+### Compiler Flags (CI only)
+- `CARGO_PROFILE_TEST_DEBUG=0` - No debug symbols
+- `CARGO_PROFILE_TEST_CODEGEN_UNITS=1` - Single codegen unit
+- `CARGO_PROFILE_TEST_LTO="thin"` - Thin link-time optimization
+- `CARGO_PROFILE_TEST_INCREMENTAL=false` - No incremental compilation
+- `RUSTFLAGS="-C link-arg=-s"` - Strip symbols
+
+### Resource Management
+- Max 2 parallel jobs in CI (vs all cores locally)
+- 4GB swap space for linking
+- Cleanup of 10GB+ of pre-installed software
+- Artifact cleanup between test batches
+
+## Testing
+The changes preserve full test coverage while working within GitHub Actions' resource constraints. Local development remains unchanged with full parallelism and debug capabilities.

--- a/scripts/test-parallel-ci.sh
+++ b/scripts/test-parallel-ci.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# Parallel test runner optimized for CI environments with limited disk space
+# Uses controlled parallelism and disk space management
+
+set -e
+
+echo "⚡ Running parallel test suite for CI environment..."
+
+# Detect number of CPU cores
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    CORES=$(sysctl -n hw.ncpu)
+else
+    CORES=$(nproc)
+fi
+
+# In CI, limit parallelism to avoid disk space issues
+if [ -n "$CI" ]; then
+    # GitHub Actions has limited disk space, reduce parallelism
+    MAX_JOBS=2
+    echo "🔧 CI environment detected, limiting to $MAX_JOBS parallel jobs (available cores: $CORES)"
+    
+    # Free up disk space before tests
+    if [ "$RUNNER_OS" == "Linux" ]; then
+        echo "🧹 Freeing up disk space..."
+        df -h
+        
+        # Clean up unnecessary files
+        sudo rm -rf /usr/local/lib/android || true
+        sudo rm -rf /usr/share/dotnet || true
+        sudo rm -rf /opt/ghc || true
+        sudo rm -rf /usr/local/.ghcup || true
+        sudo apt-get clean || true
+        
+        # Clean cargo cache selectively
+        cargo clean -p file-scanner --release || true
+        
+        echo "📊 Disk space after cleanup:"
+        df -h
+    fi
+else
+    MAX_JOBS=$CORES
+    echo "🔧 Using $MAX_JOBS CPU cores for testing"
+fi
+
+# Set optimization environment variables for CI
+if [ -n "$CI" ]; then
+    # Reduce debug info to save space
+    export CARGO_PROFILE_TEST_DEBUG=0
+    # Use fewer codegen units to reduce disk usage
+    export CARGO_PROFILE_TEST_CODEGEN_UNITS=1
+    # Keep optimization for faster tests
+    export CARGO_PROFILE_TEST_OPT_LEVEL=2
+    # Disable incremental compilation in CI
+    export CARGO_PROFILE_TEST_INCREMENTAL=false
+    # Use thin LTO to reduce binary size
+    export CARGO_PROFILE_TEST_LTO="thin"
+else
+    # Development settings
+    export CARGO_PROFILE_TEST_OPT_LEVEL=2
+    export CARGO_PROFILE_TEST_DEBUG=1
+    export CARGO_PROFILE_TEST_INCREMENTAL=true
+    export CARGO_PROFILE_TEST_CODEGEN_UNITS=16
+fi
+
+# Set test thread count
+export RUST_TEST_THREADS=$MAX_JOBS
+
+# CI-specific flags to reduce binary size
+if [ -n "$CI" ]; then
+    export RUSTFLAGS="-C link-arg=-s"  # Strip symbols
+else
+    export RUSTFLAGS="-C target-cpu=native"
+fi
+
+# Run tests in batches if in CI to manage disk space
+if [ -n "$CI" ]; then
+    echo "🔄 Running tests in batches to manage disk space..."
+    
+    # First batch: Unit tests only
+    echo "📦 Batch 1: Unit tests"
+    time cargo test \
+        --lib \
+        --bins \
+        --profile test \
+        --jobs $MAX_JOBS \
+        --quiet \
+        "$@"
+    
+    # Clean up test artifacts between batches
+    echo "🧹 Cleaning test artifacts..."
+    find target/debug -name "*.d" -delete || true
+    find target/debug -name "*.rmeta" -delete || true
+    find target/debug/deps -name "*-*" -type f ! -name "*.rlib" -delete || true
+    
+    # Second batch: Integration tests
+    echo "📦 Batch 2: Integration tests"
+    time cargo test \
+        --test "*" \
+        --profile test \
+        --jobs $MAX_JOBS \
+        --quiet \
+        "$@"
+    
+    # Third batch: Doc tests
+    echo "📦 Batch 3: Doc tests"
+    time cargo test \
+        --doc \
+        --profile test \
+        --jobs $MAX_JOBS \
+        --quiet \
+        "$@"
+else
+    # Development: Run all tests at once
+    time cargo test \
+        --profile test \
+        --jobs $MAX_JOBS \
+        --quiet \
+        "$@"
+fi
+
+echo "✅ Parallel tests completed!"

--- a/scripts/test-parallel.sh
+++ b/scripts/test-parallel.sh
@@ -4,6 +4,12 @@
 
 set -e
 
+# If running in CI, use the CI-optimized script
+if [ -n "$CI" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    exec "$SCRIPT_DIR/test-parallel-ci.sh" "$@"
+fi
+
 echo "⚡ Running parallel test suite with maximum performance..."
 
 # Detect number of CPU cores


### PR DESCRIPTION
## Summary
- Resolves GitHub Actions disk space exhaustion during parallel test compilation
- Implements CI-optimized test runner with controlled parallelism
- Adds disk space management and swap space configuration

## Problem
GitHub Actions runners were failing with "No space left on device" errors during parallel test compilation, particularly during the linking phase which requires significant disk space.

## Solution
Created a CI-specific test runner that:
1. **Reduces parallelism** - Limits to 2 parallel jobs instead of all CPU cores
2. **Frees disk space** - Removes unnecessary pre-installed software (~10GB)
3. **Optimizes binary size** - Uses minimal debug info and thin LTO
4. **Runs tests in batches** - Cleans artifacts between test types
5. **Adds swap space** - Creates 4GB swap file for more virtual memory

## Changes
- ✅ New `scripts/test-parallel-ci.sh` - CI-optimized test runner
- ✅ Updated `scripts/test-parallel.sh` - Auto-delegates to CI script when `$CI` is set
- ✅ Modified `.github/workflows/ci.yml` - Added swap space and disk cleanup
- ✅ Created `.cargo/config.toml` - Documents CI-specific settings
- ✅ Added `CI_DISK_SPACE_FIX.md` - Comprehensive documentation

## Test Plan
- [x] All tests pass locally with full parallelism
- [x] Code formatted with `cargo fmt`
- [x] No clippy warnings
- [x] MCP inspector tests pass
- [ ] CI tests pass with new configuration

🤖 Generated with [Claude Code](https://claude.ai/code)