### PR TITLE
fix: resolve clippy warnings and improve code quality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "file-scanner"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "addr2line 0.25.0",
  "anyhow",

--- a/src/binary_parser.rs
+++ b/src/binary_parser.rs
@@ -591,8 +591,7 @@ mod tests {
         let result = parse_binary(&file_path);
         // Our minimal ELF might not be valid enough for goblin to parse
         // So we test that it doesn't panic and handles the error gracefully
-        if result.is_ok() {
-            let info = result.unwrap();
+        if let Ok(info) = result {
             assert_eq!(info.format, "ELF");
             assert_eq!(info.architecture, "x86_64");
             assert_eq!(info.entry_point, Some(0x1000));
@@ -611,8 +610,7 @@ mod tests {
 
         // Note: The minimal PE might not be fully valid for goblin
         // In practice, you'd use a real PE file for testing
-        if result.is_ok() {
-            let info = result.unwrap();
+        if let Ok(info) = result {
             assert_eq!(info.format, "PE");
         }
     }

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -507,8 +507,7 @@ mod tests {
 
         // The function returns Ok with "No signature found" for nonexistent files
         // because the signature verification functions handle file errors internally
-        if result.is_ok() {
-            let info = result.unwrap();
+        if let Ok(info) = result {
             assert!(!info.is_signed);
             assert_eq!(info.verification_status, "No signature found");
         } else {

--- a/tests/test_fixtures.rs
+++ b/tests/test_fixtures.rs
@@ -248,6 +248,12 @@ pub struct TestFileBuilder {
     temp_dir: TempDir,
 }
 
+impl Default for TestFileBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TestFileBuilder {
     /// Create a new test file builder
     pub fn new() -> Self {
@@ -307,9 +313,9 @@ impl TestFileBuilder {
 
         // Create various test files
         fs::write(test_dir.join("test.txt"), "Hello World").unwrap();
-        fs::write(test_dir.join("binary.exe"), &binaries::create_pe_binary()).unwrap();
-        fs::write(test_dir.join("program"), &binaries::create_elf_binary()).unwrap();
-        fs::write(test_dir.join("data.bin"), &[0x00, 0xFF, 0x55, 0xAA]).unwrap();
+        fs::write(test_dir.join("binary.exe"), binaries::create_pe_binary()).unwrap();
+        fs::write(test_dir.join("program"), binaries::create_elf_binary()).unwrap();
+        fs::write(test_dir.join("data.bin"), [0x00, 0xFF, 0x55, 0xAA]).unwrap();
 
         test_dir
     }


### PR DESCRIPTION
- Fix unnecessary_unwrap warnings in binary_parser.rs and signature.rs by using idiomatic if-let patterns instead of is_ok()/unwrap()
- Add Default implementation for TestFileBuilder to fix new_without_default
- Remove needless borrows in test_fixtures.rs for fs::write calls
- All 952 tests passing, zero clippy warnings, clean compilation

🤖 Generated with [Claude Code](https://claude.ai/code)

## Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing
- [ ] Benchmarks

**Test Configuration**:

- Rust version:
- OS:
- Hardware:

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have run `cargo fmt` and `cargo clippy`
- [ ] I have updated the CHANGELOG.md file (if applicable)

## Screenshots (if appropriate)

## Additional context

Add any other context about the pull request here.
