### PR TITLE
[codex] fix auto-release workspace version bump

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -72,14 +72,14 @@ jobs:
           git config --global user.name 'github-actions[bot]'
           git config --global user.email 'github-actions[bot]@users.noreply.github.com'
 
-      - name: Install cargo-bump
-        run: cargo install cargo-bump
-
       - name: Determine version bump
         id: version
+        shell: bash
         run: |
+          set -euo pipefail
+
           # Get current version from Cargo.toml
-          CURRENT_VERSION=$(grep '^version =' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          CURRENT_VERSION=$(sed -n '/^\[package\]/,/^\[/{s/^version = "\(.*\)"/\1/p}' Cargo.toml | head -1)
           echo "Current version: $CURRENT_VERSION"
 
           # Determine bump type
@@ -107,9 +107,32 @@ jobs:
 
           echo "Bump type: $BUMP_TYPE"
 
-          # Bump version
-          cargo bump $BUMP_TYPE
-          NEW_VERSION=$(grep '^version =' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          IFS=. read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+          case "$BUMP_TYPE" in
+            major)
+              MAJOR=$((MAJOR + 1))
+              MINOR=0
+              PATCH=0
+              ;;
+            minor)
+              MINOR=$((MINOR + 1))
+              PATCH=0
+              ;;
+            patch)
+              PATCH=$((PATCH + 1))
+              ;;
+            *)
+              echo "::error::Unsupported version bump type: $BUMP_TYPE"
+              exit 1
+              ;;
+          esac
+
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          export NEW_VERSION
+
+          # Bump the root package and matching lockfile entry. cargo-bump does not support workspaces.
+          perl -0pi -e 's/(\[package\]\n(?:(?!^\[).*\n)*?version = ")[^"]+(")/$1$ENV{NEW_VERSION}$2/m' Cargo.toml
+          perl -0pi -e 's/(\[\[package\]\]\nname = "file-scanner"\nversion = ")[^"]+(")/$1$ENV{NEW_VERSION}$2/m' Cargo.lock
 
           echo "New version: $NEW_VERSION"
           echo "new_version=v$NEW_VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -356,8 +356,12 @@ jobs:
           rm -rf target/release/deps/*.pdb
           rm -rf target/release/deps/*.dSYM
           rm -rf target/release/incremental
-          # Remove large rlib files we don't need for tests
-          find target -name "*.rlib" -size +30M -delete
+          # Remove large rlib files we don't need for tests when the cache restored a target dir.
+          if [ -d target ]; then
+            find target -name "*.rlib" -size +30M -delete
+          else
+            echo "No target directory to clean"
+          fi
           echo "📊 Disk space after artifact cleanup:"
           df -h
 


### PR DESCRIPTION
## Summary
- replace cargo-bump in Auto Release with workspace-safe shell version bumping
- update the root Cargo.toml package version and matching file-scanner Cargo.lock entry directly
- make the Integration Tests cleanup step tolerate a missing target directory after a cache miss

## Root Cause
Auto Release installed cargo-bump and ran `cargo bump`, but cargo-bump panics for Cargo workspaces with `Workspaces are not supported yet.` The first PR #148 CI run also exposed an existing integration cleanup issue where `find target ...` failed under `bash -e` when no target cache was restored.

## Validation
- actionlint .github/workflows/auto-release.yml .github/workflows/ci.yml
- python3 YAML parse of both modified workflow files
- git diff --check
- local shell simulation: 0.2.9 -> 0.3.0 in Cargo.toml and Cargo.lock
- local shell simulation of cleanup with no target directory
