### PR TITLE
[codex] fix auto-release Rust target install

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -191,6 +191,9 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
+      - name: Ensure release target is installed
+        run: rustup target add ${{ matrix.target }}
+
       - name: Cache cargo registry
         uses: actions/cache@v4
         with:
@@ -473,6 +476,9 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Ensure release target is installed
+        run: rustup target add ${{ matrix.target }}
 
       - name: Install system dependencies (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
## Summary
- explicitly install each release matrix Rust target before build/test
- apply the same target installation to binary artifact builds

## Validation
- actionlint .github/workflows/auto-release.yml
- git diff --check