### PR TITLE
ci: adopt ThreatFlux auto-release action

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,589 +1,124 @@
 name: Auto Release
 
+concurrency:
+  group: auto-release-${{ github.event.workflow_run.head_branch || github.ref_name || 'main' }}
+  cancel-in-progress: true
+
 on:
-  push:
-    branches: [ main ]
+  workflow_run:
+    workflows: ["CI", "Security Audit"]
+    types: [completed]
+    branches: [main]
   workflow_dispatch:
     inputs:
-      version_type:
-        description: 'Version bump type'
+      version_bump:
+        description: Version bump type
         required: true
-        default: 'patch'
+        default: auto
         type: choice
         options:
+          - auto
           - patch
           - minor
           - major
 
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-  DOCKER_BUILDKIT: 1
+permissions:
+  contents: read
 
 jobs:
-  # Wait for CI to complete successfully
-  wait-for-ci:
-    name: Wait for CI
+  check:
+    name: Check for Release
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-
-    steps:
-      - name: Wait for CI workflows
-        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773 # v1.9.0
-        with:
-          ref: ${{ github.sha }}
-          check-regexp: '^(Build Cache|Lint|Test|Integration Tests|Code Coverage)$'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-          allowed-conclusions: success
-
-      - name: Wait for Security Audit
-        uses: lewagon/wait-on-check-action@2271c86c146b96545b4e871b855e10ffa6f50773 # v1.9.0
-        with:
-          ref: ${{ github.sha }}
-          check-name: 'Security Audit'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 30
-          allowed-conclusions: success,neutral,skipped
-        continue-on-error: true
-
-  # Determine version bump and update Cargo.toml
-  version-bump:
-    name: Version Bump
-    runs-on: ubuntu-latest
-    needs: [wait-for-ci]
-    if: always() && (needs.wait-for-ci.result == 'success' || github.event_name == 'workflow_dispatch')
+    if: >-
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_repository.full_name == github.repository) ||
+      github.event_name == 'workflow_dispatch'
+    permissions:
+      actions: read
+      contents: read
     outputs:
-      new_version: ${{ steps.version.outputs.new_version }}
-      version_changed: ${{ steps.version.outputs.version_changed }}
-      release_sha: ${{ steps.version.outputs.release_sha }}
-
+      should_release: ${{ steps.decide.outputs.should_release }}
+      target_sha: ${{ steps.target.outputs.sha }}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v7.0.1
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.ref_name }}
+
+      - name: Determine target SHA
+        id: target
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+            if [[ ! "${WORKFLOW_RUN_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "Invalid workflow-run head SHA" >&2
+              exit 1
+            fi
+            echo "sha=${WORKFLOW_RUN_HEAD_SHA}" >> "$GITHUB_OUTPUT"
+          else
+            echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check CI status
+        id: ci_status
+        run: |
+          TARGET_SHA="${{ steps.target.outputs.sha }}"
+          CI_STATUS=$(gh run list --workflow=ci.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          SECURITY_STATUS=$(gh run list --workflow=security.yml --branch=main --commit="$TARGET_SHA" --event=push --limit=1 --json conclusion --jq '.[0].conclusion // ""')
+          if [[ "$CI_STATUS" == "success" ]] && [[ "$SECURITY_STATUS" == "success" ]]; then
+            echo "all_passed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "all_passed=false" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Decide whether to attempt a release
+        id: decide
+        env:
+          ALL_PASSED: ${{ steps.ci_status.outputs.all_passed }}
+        run: |
+          # The release action itself no-ops when no conventional commit
+          # warrants a release, so this gate only enforces green required runs.
+          if [[ "${ALL_PASSED}" == "true" ]]; then
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  release:
+    name: Create Release
+    needs: check
+    if: needs.check.outputs.should_release == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: ${{ needs.check.outputs.target_sha }}
+
+      - name: Release
+        id: release
+        uses: ThreatFlux/github_actions/release@16d779cd569c34743eb6683ca4c0ce105e9ad234 # v0.4.2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
+          bump: ${{ github.event.inputs.version_bump || 'auto' }}
 
-      - name: Setup Git
-        run: |
-          git config --global user.name 'github-actions[bot]'
-          git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-
-      - name: Determine version bump
-        id: version
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          # Get current version from Cargo.toml
-          CURRENT_VERSION=$(sed -n '/^\[package\]/,/^\[/{s/^version = "\(.*\)"/\1/p}' Cargo.toml | head -1)
-          echo "Current version: $CURRENT_VERSION"
-
-          # Determine bump type
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            BUMP_TYPE="${{ github.event.inputs.version_type }}"
-          else
-            # Auto-determine based on commit messages since last release
-            LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-            if [ -z "$LAST_TAG" ]; then
-              COMMIT_RANGE="HEAD"
-            else
-              COMMIT_RANGE="$LAST_TAG..HEAD"
-            fi
-
-            COMMIT_MESSAGES=$(git log --pretty=format:"%s" "$COMMIT_RANGE")
-
-            if echo "$COMMIT_MESSAGES" | grep -q "BREAKING CHANGE\|!:" ; then
-              BUMP_TYPE="major"
-            elif echo "$COMMIT_MESSAGES" | grep -q "feat\|feature:" ; then
-              BUMP_TYPE="minor"
-            else
-              BUMP_TYPE="patch"
-            fi
-          fi
-
-          echo "Bump type: $BUMP_TYPE"
-
-          IFS=. read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
-          case "$BUMP_TYPE" in
-            major)
-              MAJOR=$((MAJOR + 1))
-              MINOR=0
-              PATCH=0
-              ;;
-            minor)
-              MINOR=$((MINOR + 1))
-              PATCH=0
-              ;;
-            patch)
-              PATCH=$((PATCH + 1))
-              ;;
-            *)
-              echo "::error::Unsupported version bump type: $BUMP_TYPE"
-              exit 1
-              ;;
-          esac
-
-          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
-          export NEW_VERSION
-
-          # Bump the root package and matching lockfile entry. cargo-bump does not support workspaces.
-          perl -0pi -e 's/(\[package\]\n(?:(?!^\[).*\n)*?version = ")[^"]+(")/$1$ENV{NEW_VERSION}$2/m' Cargo.toml
-          perl -0pi -e 's/(\[\[package\]\]\nname = "file-scanner"\nversion = ")[^"]+(")/$1$ENV{NEW_VERSION}$2/m' Cargo.lock
-
-          echo "New version: $NEW_VERSION"
-          echo "new_version=v$NEW_VERSION" >> "$GITHUB_OUTPUT"
-
-          # Check if version actually changed
-          if [ "$CURRENT_VERSION" != "$NEW_VERSION" ]; then
-            echo "version_changed=true" >> "$GITHUB_OUTPUT"
-
-            # Commit version change
-            git add Cargo.toml Cargo.lock
-            git commit -m "chore(release): bump version to $NEW_VERSION
-
-            Auto-generated release commit"
-
-            # Get the commit SHA
-            RELEASE_SHA=$(git rev-parse HEAD)
-            echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
-
-            # Create and push tag
-            git tag -a "v$NEW_VERSION" -m "Release v$NEW_VERSION"
-            git push origin main
-            git push origin "v$NEW_VERSION"
-
-            echo "Tagged release v$NEW_VERSION at commit $RELEASE_SHA"
-          else
-            echo "version_changed=false" >> "$GITHUB_OUTPUT"
-            echo "release_sha=${{ github.sha }}" >> "$GITHUB_OUTPUT"
-          fi
-
-  # Build and test release
-  build-and-test:
-    name: Build and Test Release
-    needs: [version-bump]
-    if: needs.version-bump.outputs.version_changed == 'true'
-    strategy:
-      matrix:
-        include:
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-          - os: macos-latest
-            target: x86_64-apple-darwin
-          - os: macos-latest
-            target: aarch64-apple-darwin
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7.0.1
-        with:
-          ref: ${{ needs.version-bump.outputs.release_sha }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Ensure release target is installed
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Cache cargo registry
-        uses: actions/cache@v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev clang lld
-
-      - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install openssl pkg-config
-
-          # Set up OpenSSL environment for cross-compilation
-          if [ "${{ matrix.target }}" = "aarch64-apple-darwin" ]; then
-            echo "Setting up OpenSSL for aarch64-apple-darwin cross-compilation"
-            OPENSSL_ROOT_DIR="$(brew --prefix openssl)"
-            export OPENSSL_ROOT_DIR
-            export OPENSSL_LIB_DIR="$OPENSSL_ROOT_DIR/lib"
-            export OPENSSL_INCLUDE_DIR="$OPENSSL_ROOT_DIR/include"
-            {
-              echo "OPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR"
-              echo "OPENSSL_LIB_DIR=$OPENSSL_LIB_DIR"
-              echo "OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_DIR"
-              echo "PKG_CONFIG_PATH=$OPENSSL_ROOT_DIR/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-            } >> "$GITHUB_ENV"
-          else
-            echo "Setting up OpenSSL for x86_64-apple-darwin"
-            OPENSSL_ROOT_DIR="$(brew --prefix openssl)"
-            export OPENSSL_ROOT_DIR
-            export OPENSSL_LIB_DIR="$OPENSSL_ROOT_DIR/lib"
-            export OPENSSL_INCLUDE_DIR="$OPENSSL_ROOT_DIR/include"
-            {
-              echo "OPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR"
-              echo "OPENSSL_LIB_DIR=$OPENSSL_LIB_DIR"
-              echo "OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_DIR"
-              echo "PKG_CONFIG_PATH=$OPENSSL_ROOT_DIR/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-            } >> "$GITHUB_ENV"
-          fi
-
-      - name: Build release
-        shell: bash
+      # Tags created with GITHUB_TOKEN do not trigger tag-push workflows, so
+      # dispatch the tag pipelines explicitly.
+      - name: Trigger tag pipelines
+        if: steps.release.outputs.released == 'true'
         env:
-          # Try to use static OpenSSL linking for better cross-compilation support
-          OPENSSL_STATIC: ${{ runner.os == 'macOS' && '1' || '0' }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
-          # Set additional OpenSSL environment variables for macOS
-          if [ "${{ runner.os }}" = "macOS" ]; then
-            OPENSSL_DIR="$(brew --prefix openssl)"
-            export OPENSSL_DIR
-            OPENSSL_ROOT_DIR="$(brew --prefix openssl)"
-            export OPENSSL_ROOT_DIR
-            export OPENSSL_LIB_DIR="$OPENSSL_DIR/lib"
-            export OPENSSL_INCLUDE_DIR="$OPENSSL_DIR/include"
-            export PKG_CONFIG_PATH="$OPENSSL_DIR/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-
-            # Additional environment variables for openssl-sys crate
-            export OPENSSL_NO_VENDOR=1
-            echo "OpenSSL configuration:"
-            echo "OPENSSL_DIR=$OPENSSL_DIR"
-            echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-            ls -la "$OPENSSL_DIR/lib" || echo "OpenSSL lib directory not found"
-          fi
-
-          cargo build --release --all-features --target "${{ matrix.target }}"
-
-      - name: Run tests
-        run: cargo test --release --all-features --target "${{ matrix.target }}"
-
-  # Create GitHub release
-  create-release:
-    name: Create GitHub Release
-    needs: [version-bump, build-and-test]
-    runs-on: ubuntu-latest
-    if: needs.version-bump.outputs.version_changed == 'true'
-    outputs:
-      upload_url: ${{ steps.create_release.outputs.upload_url }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7.0.1
-        with:
-          ref: ${{ needs.version-bump.outputs.release_sha }}
-          fetch-depth: 0
-
-      - name: Verify tag exists
-        run: |
-          echo "Checking if tag ${{ needs.version-bump.outputs.new_version }} exists..."
-          if git tag -l | grep -q "^${{ needs.version-bump.outputs.new_version }}$"; then
-            echo "✅ Tag ${{ needs.version-bump.outputs.new_version }} found"
-          else
-            echo "❌ Tag ${{ needs.version-bump.outputs.new_version }} not found"
-            echo "Available tags:"
-            git tag -l | head -10
-            exit 1
-          fi
-
-      - name: Generate changelog
-        id: changelog
-        run: |
-          LAST_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
-          if [ -z "$LAST_TAG" ]; then
-            COMMIT_RANGE="HEAD"
-          else
-            COMMIT_RANGE="$LAST_TAG..HEAD"
-          fi
-
-          echo "## What's Changed" > release_notes.md
-          echo "" >> release_notes.md
-
-          # Generate changelog from commits
-          git log --pretty=format:"- %s (%h)" "$COMMIT_RANGE" | grep -v "^- chore(release):" >> release_notes.md || echo "- Initial release" >> release_notes.md
-
-          echo "" >> release_notes.md
-          echo "**Full Changelog**: https://github.com/${{ github.repository }}/compare/${LAST_TAG}...${{ needs.version-bump.outputs.new_version }}" >> release_notes.md
-
-      - name: Create Release
-        id: create_release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ needs.version-bump.outputs.new_version }}
-          name: File Scanner ${{ needs.version-bump.outputs.new_version }}
-          body_path: release_notes.md
-          draft: false
-          prerelease: ${{ contains(needs.version-bump.outputs.new_version, '-') }}
-          generate_release_notes: true
-
-  # Publish to crates.io
-  publish-crate:
-    name: Publish to crates.io
-    needs: [version-bump, build-and-test, create-release]
-    runs-on: ubuntu-latest
-    if: needs.version-bump.outputs.version_changed == 'true' && vars.PUBLISH_CRATE == 'true'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7.0.1
-        with:
-          ref: ${{ needs.version-bump.outputs.release_sha }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-
-      - name: Cache cargo registry
-        uses: actions/cache@v6.1.0
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-publish-${{ hashFiles('**/Cargo.lock') }}
-
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev clang lld
-
-      - name: Verify package
-        run: cargo package --allow-dirty
-
-      - name: Publish to crates.io
-        if: env.CARGO_REGISTRY_TOKEN != ''
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --token ${{ env.CARGO_REGISTRY_TOKEN }} --allow-dirty
-        continue-on-error: true
-
-  # Build and push Docker image
-  build-docker:
-    name: Build Docker Image
-    needs: [version-bump, create-release]
-    runs-on: ubuntu-latest
-    if: needs.version-bump.outputs.version_changed == 'true'
-    outputs:
-      digest: ${{ steps.build.outputs.digest }}
-      image-ref: ${{ steps.image-ref.outputs.image-ref }}
-    permissions:
-      contents: read
-      packages: write
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7.0.1
-        with:
-          ref: ${{ needs.version-bump.outputs.release_sha }}
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-        with:
-          driver-opts: |
-            network=host
-            image=moby/buildkit:latest
-
-      - name: Log in to Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata
-        id: meta
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
-        with:
-          images: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}},value=${{ needs.version-bump.outputs.new_version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ needs.version-bump.outputs.new_version }}
-            type=semver,pattern={{major}},value=${{ needs.version-bump.outputs.new_version }}
-            type=raw,value=latest
-          labels: |
-            org.opencontainers.image.title=File Scanner
-            org.opencontainers.image.description=Comprehensive file analysis and threat detection tool
-            org.opencontainers.image.vendor=ThreatFlux
-            org.opencontainers.image.licenses=MIT OR Apache-2.0
-            maintainer=ThreatFlux Team
-
-      - name: Generate build args
-        id: build_args
-        run: |
-          {
-            echo "VERSION=${GITHUB_REF#refs/tags/}"
-            echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-            echo "VCS_REF=$(git rev-parse --short HEAD)"
-          } >> "$GITHUB_OUTPUT"
-
-      - name: Build and push Docker image
-        id: build
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            VERSION=${{ steps.build_args.outputs.VERSION }}
-            BUILD_DATE=${{ steps.build_args.outputs.BUILD_DATE }}
-            VCS_REF=${{ steps.build_args.outputs.VCS_REF }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
-      - name: Generate image reference
-        id: image-ref
-        run: |
-          echo "image-ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}" >> "$GITHUB_OUTPUT"
-
-  # Build and release binaries for all platforms
-  build-binaries:
-    name: Build Binaries
-    needs: [version-bump, create-release]
-    strategy:
-      matrix:
-        include:
-          # Linux
-          - os: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            name: linux-amd64
-          # Windows
-          - os: windows-latest
-            target: x86_64-pc-windows-msvc
-            name: windows-amd64
-          # macOS
-          - os: macos-latest
-            target: x86_64-apple-darwin
-            name: macos-amd64
-          - os: macos-latest
-            target: aarch64-apple-darwin
-            name: macos-arm64
-
-    runs-on: ${{ matrix.os }}
-    if: needs.version-bump.outputs.version_changed == 'true'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v7.0.1
-        with:
-          ref: ${{ needs.version-bump.outputs.release_sha }}
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
-        with:
-          targets: ${{ matrix.target }}
-
-      - name: Ensure release target is installed
-        run: rustup target add ${{ matrix.target }}
-
-      - name: Install system dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y pkg-config libssl-dev clang lld
-
-      - name: Install system dependencies (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install openssl pkg-config
-
-          # Set up OpenSSL environment for cross-compilation
-          OPENSSL_ROOT_DIR="$(brew --prefix openssl)"
-          export OPENSSL_ROOT_DIR
-          export OPENSSL_LIB_DIR="$OPENSSL_ROOT_DIR/lib"
-          export OPENSSL_INCLUDE_DIR="$OPENSSL_ROOT_DIR/include"
-          {
-            echo "OPENSSL_ROOT_DIR=$OPENSSL_ROOT_DIR"
-            echo "OPENSSL_LIB_DIR=$OPENSSL_LIB_DIR"
-            echo "OPENSSL_INCLUDE_DIR=$OPENSSL_INCLUDE_DIR"
-            echo "PKG_CONFIG_PATH=$OPENSSL_ROOT_DIR/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-          } >> "$GITHUB_ENV"
-
-      - name: Build binary
-        shell: bash
-        env:
-          # Try to use static OpenSSL linking for better cross-compilation support
-          OPENSSL_STATIC: ${{ runner.os == 'macOS' && '1' || '0' }}
-        run: |
-          # Set additional OpenSSL environment variables for macOS
-          if [ "${{ runner.os }}" = "macOS" ]; then
-            OPENSSL_DIR="$(brew --prefix openssl)"
-            export OPENSSL_DIR
-            OPENSSL_ROOT_DIR="$(brew --prefix openssl)"
-            export OPENSSL_ROOT_DIR
-            export OPENSSL_LIB_DIR="$OPENSSL_DIR/lib"
-            export OPENSSL_INCLUDE_DIR="$OPENSSL_DIR/include"
-            export PKG_CONFIG_PATH="$OPENSSL_DIR/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
-
-            # Additional environment variables for openssl-sys crate
-            export OPENSSL_NO_VENDOR=1
-            echo "OpenSSL configuration:"
-            echo "OPENSSL_DIR=$OPENSSL_DIR"
-            echo "PKG_CONFIG_PATH=$PKG_CONFIG_PATH"
-            ls -la "$OPENSSL_DIR/lib" || echo "OpenSSL lib directory not found"
-          fi
-
-          cargo build --release --all-features --target "${{ matrix.target }}"
-
-      - name: Create archive (Unix)
-        if: runner.os != 'Windows'
-        run: |
-          cd "target/${{ matrix.target }}/release"
-          tar czf "../../../file-scanner-${{ needs.version-bump.outputs.new_version }}-${{ matrix.name }}.tar.gz" file-scanner
-          cd ../../../
-          shasum -a 256 "file-scanner-${{ needs.version-bump.outputs.new_version }}-${{ matrix.name }}.tar.gz" > "file-scanner-${{ needs.version-bump.outputs.new_version }}-${{ matrix.name }}.tar.gz.sha256"
-
-      - name: Create archive (Windows)
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          cd "target/${{ matrix.target }}/release"
-          7z a "../../../file-scanner-${{ needs.version-bump.outputs.new_version }}-${{ matrix.name }}.zip" file-scanner.exe
-          cd ../../../
-          sha256sum "file-scanner-${{ needs.version-bump.outputs.new_version }}-${{ matrix.name }}.zip" > "file-scanner-${{ needs.version-bump.outputs.new_version }}-${{ matrix.name }}.zip.sha256"
-
-      - name: Upload binary to release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
-        with:
-          tag_name: ${{ needs.version-bump.outputs.new_version }}
-          files: |
-            file-scanner-${{ needs.version-bump.outputs.new_version }}-${{ matrix.name }}.*
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-  # Notify completion
-  notify:
-    name: Release Complete
-    needs: [version-bump, build-and-test, create-release, build-docker, build-binaries]
-    runs-on: ubuntu-latest
-    if: always() && needs.version-bump.outputs.version_changed == 'true'
-
-    steps:
-      - name: Release Status
-        run: |
-          if [ "${{ needs.build-and-test.result }}" = "success" ] && \
-             [ "${{ needs.build-docker.result }}" = "success" ]; then
-            echo "✅ Auto-release ${{ needs.version-bump.outputs.new_version }} completed successfully!"
-            echo "🐳 Docker images pushed to GHCR"
-            echo "📦 Binary artifacts uploaded"
-            echo "📚 Release created on GitHub"
-          else
-            echo "❌ Auto-release ${{ needs.version-bump.outputs.new_version }} failed"
-            echo "Build/Test: ${{ needs.build-and-test.result }}"
-            echo "Docker Build: ${{ needs.build-docker.result }}"
-            exit 1
-          fi
+          gh workflow run docker.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -279,7 +279,7 @@ jobs:
     name: Sign Container
     needs: [build, scan]
     runs-on: ${{ vars.RUST_TEMPLATE_RUNNER_UBUNTU || 'ubuntu-latest' }}
-    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    if: github.event_name != 'pull_request' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Adopts the ThreatFlux auto-release action, replacing the bespoke ~590-line auto-release pipeline.

## What the action does

`ThreatFlux/github_actions/release` performs a conventional-commit-driven version bump: it inspects commits since the last tag, decides the bump (or takes an explicit `patch`/`minor`/`major` via `workflow_dispatch`), rewrites `Cargo.toml`/`Cargo.lock`, and creates the tag and GitHub Release through the GitHub API — no `git push` or `cargo` invocations at runtime. Merges that contain only `chore:`/`docs:`/`ci:` commits produce **no** release; the action no-ops. (This PR itself uses a `ci:` prefix deliberately so merging it does not trigger a bump.)

The workflow is gated: it runs on `workflow_run` completion of **CI** and **Security Audit** on `main`, and the `check` job re-verifies via `gh run list` that both workflows concluded `success` for the exact target SHA before releasing.

## GITHUB_TOKEN tag-trigger limitation and dispatch chaining

Tags created with `GITHUB_TOKEN` do not trigger tag-push (`on: push: tags:`) workflows. To compensate, the release job explicitly dispatches `docker.yml` on the new tag (`gh workflow run docker.yml --ref <tag>`), so tagged container images still get built, scanned, and signed. There is no `release.yml` in this repo, so no other tag pipeline needs chaining.

## docker.yml fix

- The cosign `sign` job was gated `github.ref == 'refs/heads/main'` only, so images built from `v*` tags were never signed. The condition now also matches `startsWith(github.ref, 'refs/tags/v')`.

The other suspected template bugs (missing `shell: bash` on a native build step, crates.io heredoc terminator, Windows package step missing its `.sha256` file) live in `release.yml`, which this repo does not have — nothing to patch.

## Behavior removed with the old auto-release.yml

The replaced workflow did substantially more than bump/tag/release. The following is **removed** by this PR:

- **crates.io publish** (was gated behind `vars.PUBLISH_CRATE == 'true'` + `CARGO_REGISTRY_TOKEN`; ran with `continue-on-error`).
- **Multi-platform binary builds** (Linux amd64, Windows amd64, macOS amd64/arm64) and upload of `.tar.gz`/`.zip` + `.sha256` artifacts to the GitHub Release.
- **Release build + test verification** across those four targets before releasing.
- **A second Docker build/push to GHCR** inside auto-release (redundant with `docker.yml`, which remains and is now dispatch-chained on tags).

If binary release artifacts or crates.io publishing are still wanted, they should come back as a dedicated tag-triggered `release.yml` (which the dispatch step here could then chain).

## Pinning

The action ref is SHA-pinned to `ThreatFlux/github_actions/release@16d779c` (v0.4.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
